### PR TITLE
Fixed navbar iteration over displayInMenu property

### DIFF
--- a/bootstrap3-components/src/main/resources/bootstrap3nt_navbar/html/navbar.menu.groovy
+++ b/bootstrap3-components/src/main/resources/bootstrap3nt_navbar/html/navbar.menu.groovy
@@ -17,10 +17,10 @@ printMenu = { node, navMenuLevel ->
                 if (menuItem.isNodeType("jmix:navMenu")) {
                     correctType = false;
                 }
-                if (menuItem.properties['j:displayInMenu']) {
+                if (menuItem.properties['j:displayInMenuName']) {
                     correctType = false;
-                    menuItem.properties['j:displayInMenu'].each() {
-                        correctType |= (it.node.identifier == currentNode.identifier)
+                    menuItem.properties['j:displayInMenuName'].each() {
+                        correctType |= (it.string.equals(currentNode.name))
                     }
                 }
                 if (correctType) {


### PR DESCRIPTION
The current version of the if-block is not iterating over the right property. As of Jahia 7, templates are stored by their node-name and not their UUID. So we should iterate over the selected menu names and check against the name of the current node.
j:displayInMenu has changed to j:displayInMenuName
